### PR TITLE
Fixing the dropdown menu toggle icon

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -19,7 +19,7 @@
     <header>
       <!-- Site navbar > will be visible at all times apart from the landing page (though minimised on smaller screens) -->
       <nav id="navIcon">
-        <a id="navToggleIcon" href="#void" onclick="toggleMenu()">&#9776;</a>
+        <button id="navToggleIcon" onclick="toggleMenu()">&#9776;</button>
         <a href="/"><span>ML</span></a>
       </nav>
       <nav id="topNav">

--- a/public/mediaQuery.css
+++ b/public/mediaQuery.css
@@ -48,6 +48,11 @@
     flex-direction: row;
     justify-content: space-between;
   }
+  #navIcon button {
+    color: #fff;
+    font-size: inherit;
+    padding: 0 1em;
+  }
   #navIcon a {
     display: inline-block;
     font-family: 'Poiret One', sans-serif;
@@ -91,11 +96,9 @@
 
     padding-top: 4em;
   }
-
   #topNav_responsive li:nth-child(2) {
     display: none;
   }
-
   #topNav_responsive a {
     display: block;
     width: 95vw;
@@ -104,7 +107,6 @@
     text-align: right;
     padding: 0.2em 1em 0.4em 0;
   }
-
   #topNav_responsive a:hover {
     color: #B8CCC1;
     transition: 0.2s;
@@ -115,5 +117,8 @@
   h1 {
     font-size: 3em;
     padding: 1rem;
+  }
+  #landingPage {
+    overflow: hidden;
   }
 }

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -19,7 +19,7 @@
     <header>
       <!-- Site navbar > will be visible at all times apart from the landing page (though minimised on smaller screens) -->
       <nav id="navIcon">
-        <a id="navToggleIcon" href="#void">&#9776;</a>
+        <a id="navToggleIcon" href="#void" onclick="toggleMenu()">&#9776;</a>
         <a href="/"><span>ML</span></a>
       </nav>
       <nav id="topNav">

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -19,7 +19,7 @@
     <header>
       <!-- Site navbar > will be visible at all times apart from the landing page (though minimised on smaller screens) -->
       <nav id="navIcon">
-        <a id="navToggleIcon" href="#void" onclick="toggleMenu()">&#9776;</a>
+        <button id="navToggleIcon" onclick="toggleMenu()">&#9776;</button>
         <a href="/"><span>ML</span></a>
       </nav>
       <nav id="topNav">

--- a/public/script.js
+++ b/public/script.js
@@ -1,31 +1,12 @@
 // Set up dropdown menu for small screens
 
-// window.addEventListener("load", () => {   // Enable the below functions on page load
+const icon = document.getElementById("navToggleIcon");
+const navbar = document.getElementById("topNav");
 
-  const icon = document.getElementById("navToggleIcon");
-  const navbar = document.getElementById("topNav");
-
-  function toggleMenu() {
-
-    // ["click", "touchstart"].forEach( input => {   // Could use touchstart only ; supposed to work on touch and click >> tried and it didn't work
-      // icon.addEventListener("click", (e) => {
-      //   e.preventDefault()    // Prevent 'click' to be triggered as well when tapping on the icon using touch screens
-
-        if (navbar.id === "topNav") {
-          navbar.id += "_responsive";   // Change id of element to 'topNav_responsive'
-        } else {
-          navbar.id = "topNav";   // If id name is already 'topNav_responsive', change it back to 'topNav'
-        }
-      // }, false);
-    // });
+function toggleMenu() {
+  if (navbar.id === "topNav") {
+    navbar.id += "_responsive";   // Change id of element to 'topNav_responsive'
+  } else {
+    navbar.id = "topNav";   // If id name is already 'topNav_responsive', change it back to 'topNav'
   }
-
-// }, false);
-
-// icon.addEventListener("click", (e) => {
-//   if (navbar.id === "topNav") {
-//     navbar.id += "_responsive";
-//   } else {
-//     navbar.id = "topNav";
-//   }
-// });
+}


### PR DESCRIPTION
- As the last commit enabled the drowdown menu toggle icon on touch screens:
  - Cleaned up the JS code
  - Updated the nav bar HTML code for the Portfolio page, to be identical to that for the About page
- Changed the menu toggle item element from a link to a button, to avoid having to include an obsolete link within the 'a' element
- Updated the CSS as necessary (within mediaQuery.css) to make the icon look the same
- Added a media query to the landing page, to disable scrolling (x+y) when viewing the landing page