### PR TITLE
Replacing svg link with onClick()

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,8 +20,9 @@
     <header id="landingPage">
       <!-- <h1><a href="/about">Madeleine<br/>Linder</a></h1> -->
 
-      <svg height="600" width="600" viewBox="0 0 600.000000 600.000000">
-        <a href="/about">
+      <!-- When click on svg, trigger function enterSite(), which will take the user to path "/about"
+      Have to set it up as a function, as adding a link within the svg did not function on touchscreen -->
+      <svg height="600" width="600" viewBox="0 0 600.000000 600.000000" onclick="enterSite()">
         <!-- Use translate() to center the visible parts of the svg -->
         <g transform="translate(21.000000,584.000000) scale(0.100000,-0.100000)"
         fill="#fff" stroke="none">
@@ -127,7 +128,7 @@
         4 -35 4 -46 -1z"/>
         <path d="M4088 1587 c-18 -14 -48 -112 -48 -155 0 -19 4 -22 23 -17 12 4 37
         23 55 43 29 32 33 42 30 87 -2 41 -6 50 -23 52 -11 2 -28 -3 -37 -10z"/> -->
-        </a>
+        <!-- </a> -->
       </svg>
 
       <!-- <h1 id="pageTitle">Madeleine</br>Linder</h1> -->

--- a/public/script.js
+++ b/public/script.js
@@ -10,3 +10,9 @@ function toggleMenu() {
     navbar.id = "topNav";   // If id name is already 'topNav_responsive', change it back to 'topNav'
   }
 }
+
+// Go to path "/about" when click on landing page svg
+// Have to set it up as a function, as adding a link within the svg did not function on touchscreen
+function enterSite() {
+  window.location.pathname = "/about";
+}


### PR DESCRIPTION
Adding onClick() attribute to the svg element on the landing page (and removing the link within the svg; ocClick() triggers function enterSite(), which will take the user to the path "/about".
Have to set it up as a function, as adding a link within the svg did not function on touchscreen.