### PR TITLE
Updating media queries to remove excess empty vertical space on small screens

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -130,12 +130,6 @@
         23 55 43 29 32 33 42 30 87 -2 41 -6 50 -23 52 -11 2 -28 -3 -37 -10z"/> -->
         <!-- </a> -->
       </svg>
-
-      <!-- <h1 id="pageTitle">Madeleine</br>Linder</h1> -->
-      <!-- Landing page button > will take you to the page content -->
-      <!-- <span id="pageStart"><a href="/portfolio"><img src="assets/ML.png" /></a></span> -->
-      <!-- <span id="pageStart"><a href="/portfolio"><img src="assets/arrowSymbol.png" /></a></span> -->
-          <!-- original arrow symbol: &#8615; -->
     </header>
 
     <!-- link to the JavaScript file -->

--- a/public/main.css
+++ b/public/main.css
@@ -140,6 +140,11 @@ main {
   align-items: center;
 }
 
+.text .column {
+  /*margin: 0;
+  padding: 0;*/
+}
+
 /* Site navbar */
 #topNav {
   height: 4em;
@@ -205,12 +210,12 @@ img {
   margin: 1em;
 }
 
-.banner img {
+/*.banner img {
   height: 3em;
   width: 3em;
   border-radius: 3em;
   margin: 0 2em;
-}
+}*/
 
 .text {
   width: 62vw;

--- a/public/mediaQuery.css
+++ b/public/mediaQuery.css
@@ -1,11 +1,4 @@
-@media screen and (max-width: 750px){
-  /* To make the site look good on smaller screens: */
-  main {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    overflow-x: hidden;
-  }
+@media screen and (max-width: 950px){
   .row {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -16,6 +9,29 @@
   .text {
     width: 85%;
   }
+  .leftAlign, .rightAlign, .leftAlign h3, .rightAlign h3, .leftAlign h4, .rightAlign h4 {
+    text-align: center;
+    padding-left: 0;
+    padding-right: 0;
+  }
+  #iconList {
+    -webkit-flex-direction: row;
+    -ms-flex-direction: row;
+    flex-direction: row;
+  }
+  #iconList a {
+    margin: 1em;
+  }
+}
+
+@media screen and (max-width: 750px){
+  /* To make the site look good on smaller screens: */
+  main {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    overflow-x: hidden;
+  }
   h1 {
     font-size: 4em;
   }
@@ -23,11 +39,6 @@
     max-width: 92vw;
     height: auto;
     max-height: 35vh;
-  }
-  .leftAlign, .rightAlign, .leftAlign h3, .rightAlign h3, .leftAlign h4, .rightAlign h4 {
-    text-align: center;
-    padding-left: 0;
-    padding-right: 0;
   }
   #topNav {
     background-size: 162vw auto;
@@ -74,14 +85,6 @@
   #navIcon a span {
     border: 2px solid #fff;
     padding: 0.1em;
-  }
-  #iconList {
-    -webkit-flex-direction: row;
-    -ms-flex-direction: row;
-    flex-direction: row;
-  }
-  #iconList a {
-    margin: 1em;
   }
 
   /* The dropdown menu: */

--- a/public/mediaQuery.css
+++ b/public/mediaQuery.css
@@ -10,6 +10,11 @@
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
     flex-direction: column;
+    -ms-align-items: center;
+    align-items: center;
+  }
+  .text {
+    width: 85%;
   }
   h1 {
     font-size: 4em;
@@ -128,5 +133,8 @@
   }
   #landingPage {
     overflow: hidden;
+  }
+  .text {
+    width: 90%;
   }
 }

--- a/server.js
+++ b/server.js
@@ -16,9 +16,9 @@ app.get('/', function (request, response) {
   // response.sendFile(__dirname + '/public/index.html'); // Redundant code
 });
 
-app.get('/testing', function (request, response) {
-  response.sendFile(__dirname + '/public/wrapper.html');
-});
+// app.get('/testing', function (request, response) {
+//   response.sendFile(__dirname + '/public/wrapper.html');
+// });
 
 app.get('/about', function (request, response) {
   response.sendFile(__dirname + '/public/about.html');


### PR DESCRIPTION
- Added media queries to remove excess empty vertical space along the sides on small screens:
  - Added them, and moved some existing media query styling, so that the layout and size of textboxes and columns change at a greater breakpoint (950px instead of 750px)
- Removed and commented out some redundant code