### PR TITLE
Updating media queries to remove excess empty vertical space on small screens

### DIFF
--- a/public/mediaQuery.css
+++ b/public/mediaQuery.css
@@ -1,4 +1,10 @@
 @media screen and (max-width: 950px){
+  main {
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    overflow-x: hidden;
+  }
   .row {
     -webkit-flex-direction: column;
     -ms-flex-direction: column;
@@ -26,12 +32,6 @@
 
 @media screen and (max-width: 750px){
   /* To make the site look good on smaller screens: */
-  main {
-    -webkit-flex-direction: column;
-    -ms-flex-direction: column;
-    flex-direction: column;
-    overflow-x: hidden;
-  }
   h1 {
     font-size: 4em;
   }


### PR DESCRIPTION
- Added media queries to remove excess empty vertical space along the sides on small screens:
  - Added them, and moved some existing media query styling, so that the layout and size of textboxes and columns change at a greater breakpoint (950px instead of 750px)
- Removed and commented out some redundant code