### PR TITLE
Update page design slightly; link/hover colours and padding around emphasised text

### DIFF
--- a/public/main.css
+++ b/public/main.css
@@ -29,7 +29,7 @@ p {
 
 a {
   text-decoration: none;
-  color: #4c58ed;
+  color: #616BEF;
 }
 
 em {
@@ -202,8 +202,8 @@ main {
 
 .popup {
   display: none;
-  background-color: #dedede;
-  /*background-color: #cdcdcd;*/
+  background-color: #EFEFEF;
+  border-radius: 1em;
 }
 
 /* ///////// ///////// ///////// ///////// ///////// ///////// /////////
@@ -233,7 +233,7 @@ img {
 }
 
 #iconColumn a:hover {
-  background-color: #4c58ed;
+  background-color: #8A92F3;
   /*background-color: #6E8F88;*/
   transition: 0.2s;
 }
@@ -267,8 +267,7 @@ img {
   border: 2px solid #111;
   padding: 0.3em 0.5em;
   border-radius: 0.4em;
-
-  margin: 1em;  /* Ev update spacing when remove the working borders */
+  margin: 1em;
 }
 
 /* ////////    The Portfolio page work example preview section    //////// */
@@ -294,8 +293,7 @@ img {
   padding: 0.3em 0.5em;
   border-radius: 0.4em;
   line-height: 1.2em;  /* Specify line height to ensure that the link is vertically centered within the span borders */
-
-  margin: 1em;  /* Ev update spacing when remove the working borders */
+  margin: 1em;
 }
 
 /* ///////// ///////// ///////// ///////// ///////// ///////// /////////

--- a/public/main.css
+++ b/public/main.css
@@ -34,7 +34,7 @@ a {
 
 em {
   background-color: #c7cbf9;
-  padding: 0.5em;
+  padding: 0.4em;
   border-radius: 0.4em;
 }
 

--- a/public/mediaQuery.css
+++ b/public/mediaQuery.css
@@ -1,5 +1,12 @@
 /* To make the site look good on smaller screens (<950px, <750px and <450px) */
 
+@media screen and (max-width: 1100px){
+  em {
+    /* Keep the background colour from overlapping nearby text when the paragraph is spread over more than one line */
+    padding: 0.2em;
+  }
+}
+
 @media screen and (max-width: 950px){
   img {
     min-height: 25vh;  /* Ensures that when the screen is 750-950px wide > the work example screenshot will remain the same height, but be slightly squished width-wise > ev change this */

--- a/public/script.js
+++ b/public/script.js
@@ -36,8 +36,7 @@ function togglePopup(buttonId) {
     window.location.href = ("/portfolio\#" + sectionId);  // Makes the window jump back to the top of the section the user was just looking at > to avoid the screen seemingly jumping to a later section, and skipping work examples, when closing a popup section
   } else {
     currentPopup.style.display = "block";
-    currentButton.style.borderColor = "#4c58ed";
-    // currentButton.style.borderColor = "#92626F";
+    currentButton.style.borderColor = "#616BEF";
     currentButtonText.textContent = "Find out more ⇑";
 
     // Send event info to Google Analytics when user clicks on a button to display more information about a work example


### PR DESCRIPTION
- Updated the links and hover colours to be different shades of the same blue hue
- Updated the popup background colour to be a slightly lighter grey
- Decreased the amount of padding around emphasised text on smaller devices, to keep the background colour from overlapping nearby text when the paragraph is spread over more than one line