### PR TITLE
Add links to CF:G competition winners page and update readme wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Portfolio
 
-A website containing my personal portfolio and the main projects I have created.
+A website containing my personal portfolio and some of the projects I have created.
 
 The site can be accessed on [madeleinelinder.com](http://www.madeleinelinder.com/?utm_source=github).

--- a/public/about.html
+++ b/public/about.html
@@ -54,7 +54,7 @@
           </div>
           <div class="leftAlign">
             <h1>Accomplishments</h1>
-            <p>Winner of the <a href="http://www.codefirstgirls.org.uk/" target="_blank">Code First: Girls</a> Introduction to Web Development course competition at The Guardian (2017).</p>
+            <p><a href="http://www.codefirstgirls.org.uk/course-competition.html" target="_blank">Winner of the Code First: Girls Introduction to Web Development course competition at The Guardian (2017).</a></p>
             <p>First Class degree with Honours, <a href="http://www.city.ac.uk/courses/undergraduate/psychology" target="_blank">BSc Psychology from City, University of London</a> (2016).</p>
             <p>Nominated for Mentee of the Year by the <a href="http://www.city.ac.uk/careers/recruiters/get-involved-on-campus/mentoring" target="_blank">City, University of London Professional Mentoring team</a> (2016), and asked to speak at the End-of-Year awards ceremony.</p>
             <p>Graduate of the Year, Project of the Year and Excellent Mathematical Accomplishment from <a href="https://www.jensengymnasium.se/norra" target="_blank">Jensen Gymnasium Norra</a> (2011).</p>

--- a/public/portfolio.html
+++ b/public/portfolio.html
@@ -119,7 +119,7 @@
             <div class="leftAlign">
               <h1>Our Story</h1>
               <p>A website created to provide a positive view of immigration in the UK.</p>
-              <p>Winner of the <a href="http://www.codefirstgirls.org.uk/" target="_blank">Code First: Girls</a> Introduction to Web Development course competition at The Guardian (2017).</p>
+              <p><a href="http://www.codefirstgirls.org.uk/course-competition.html" target="_blank">Winner of the Code First: Girls Introduction to Web Development course competition at The Guardian (2017).</a></p>
               <p>Tech Stack: HTML5/CSS3, Twitter API Bootstrap and jQuery.</p>
             </div>
           </div>


### PR DESCRIPTION
- Added a link to the CF:G course competition winners page where mention that OurStory won the competition, on the About and Portfolio pages
- Updated wording in the readme