### PR TITLE
Update URL tracker tag within the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A website containing my personal portfolio and the main projects I have created.
 
-The site can be accessed on [madeleinelinder.com](http://www.madeleinelinder.com/?utm_source=github.com).
+The site can be accessed on [madeleinelinder.com](http://www.madeleinelinder.com/?utm_source=github).


### PR DESCRIPTION
As a URL tracker tag of "github.com" shows up as direct/none on GA; changing the tag back to "github"